### PR TITLE
Enable get_report to take a block

### DIFF
--- a/.env-dev-values
+++ b/.env-dev-values
@@ -1,0 +1,1 @@
+ALMA_API_HOST='https://api-na.hosted.exlibrisgroup.com'

--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,1 @@
+ALMA_API_KEY='almaapikey'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,16 +6,16 @@ jobs:
   # Run tests
   test:
     runs-on: ubuntu-latest
-    env:
-      ALMA_API_KEY: 'YOUR_ALMA_API_KEY'
-      ALMA_API_HOST: 'https://api-na.hosted.exlibrisgroup.com'
     steps:
       - uses: actions/checkout@v2
+      - name: Create .env file
+        run: cat .env-example > .env
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v1.0.2
       - name: Set up Ruby 2.7.2
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.2
-      - name: Bundle install
-        run: bundle install --jobs 4 --retry 3
+          bundler-cache: true
       - name: Run tests
         run: bundle exec rspec

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Create .env file
-        run: cat .env-example > .env
+        run: cat .env-example .env-dev-values > .env
       - name: Load .env file
         uses: xom9ikk/dotenv@v1.0.2
       - name: Set up Ruby 2.7.2
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.2
-          bundler-cache: true
+      - name: Bundle install
+        run: bundle install
       - name: Run tests
         run: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 
 .byebug_history
 .env
+.irb_history

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 
 .byebug_history
+.env

--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,1 @@
+require 'alma_rest_client'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,20 @@
 FROM ruby:2.7.2
+ARG UNAME=app
+ARG UID=1000
+ARG GID=1000
 
-LABEL maintainer="nique.rio@gmail.com"
+LABEL maintainer="mrio@umich.edu"
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
-  apt-transport-https
-
-
-RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
-  vim 
+  vim
 
 RUN gem install bundler:2.1.4
-
-COPY  Gemfile* /app/
-COPY alma_rest_client.gemspec /app/
-COPY lib/alma_rest_client/version.rb /app/lib/alma_rest_client/version.rb
-
 ENV BUNDLE_PATH /gems
 
-WORKDIR /app
-RUN bundle install
+RUN groupadd -g ${GID} -o ${UNAME}
+RUN useradd -m -d /app -u ${UID} -g ${GID} -o -s /bin/bash ${UNAME}
+RUN mkdir -p /gems && chown ${UID}:${GID} /gems
+USER $UNAME
 
-COPY  . /app
+
+WORKDIR /app

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in alma_rest_client.gemspec
 gemspec
-
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    alma_rest_client (1.0.1)
+    alma_rest_client (1.1.0)
       activesupport (~> 6.0, >= 4.2)
       httparty
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,15 +26,14 @@ GEM
     httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0901)
+    mime-types-data (3.2021.1115)
     minitest (5.14.4)
     multi_xml (0.6.0)
     public_suffix (4.0.6)
-    rake (12.3.3)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -48,7 +47,7 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
+    rspec-support (3.10.3)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -69,8 +68,7 @@ PLATFORMS
 DEPENDENCIES
   alma_rest_client!
   byebug
-  rake (~> 12.0)
-  rspec (~> 3.0)
+  rspec
   simplecov
   webmock
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ end
 
 ## How to Contribute
 
+Clone the repository and cd into it
+```
+$ git clone git@github.com:mlibrary/alma_rest_client.git
+$ cd alma_rest_client
+```
+
 Copy .env-example to .env
 ```
 $ cp .env-example .env

--- a/README.md
+++ b/README.md
@@ -78,3 +78,22 @@ response = client.get_report(path: '/shared/University of Michigan 01UMICH_INST/
   my_array.push(row)
 end
 ```
+
+## How to Contribute
+
+Copy .env-example to .env
+```
+$ cp .env-example .env
+```
+
+Replace the value for `ALMA_API_KEY` with a real key with appropriate permissions
+
+Build the image
+```
+$ docker-compose build
+```
+
+Run the tests
+```
+$ docker-compose run --rm web bundle exec rspec
+```

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Build the image
 $ docker-compose build
 ```
 
+Install the gems
+```
+$ docker-compose run --rm web bundle install
+```
+
+
 Run the tests
 ```
 $ docker-compose run --rm web bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -59,7 +59,12 @@ response = client.get_all(url: '/users/soandso/loans', record_key: 'item_loan')
 #get_all with options; this method overwrites 'limit' and 'offset'
 response = client.get_all(url: '/users/soandso/loans', record_key: 'item_loan', query: {"expand" => "renewable"})
 ```
-`get_report` method tries twice to get a full report from Alma. This returns an AlmaRestClient::Response object which has a code, message, and parsed_response. For a successfully retrieved report, the parsed response is an array of report rows. Each row element is a hash where the keys are the column names of the report. `get_report` method uses the keyword argument `:path` 
+`get_report` method is used for working Alma Analytics reports. It takes the argument `:path` which is the path to the analytics report. It can take a block or no block.
+
+When no block is given to `get_report` it returns an `AlmaRestClient::Response` object which has a code, messsage, and parsed_response. The parsed response is an array of report rows. Each row element is a hash where the keys are the column names of the report. 
+
+When a block is given, the block can work with a row of the report. Each row is a hash where the keys are the column names of the report. If it's successful it will return a successful `AlmaRestClient::Response` object.  
+
 
 ```ruby
 #all are instance methods
@@ -68,4 +73,8 @@ client = AlmaRestClient.client
 #get_report
 response = client.get_report(path: '/shared/University of Michigan 01UMICH_INST/Reports/fake-data')
 
+my_array = []
+response = client.get_report(path: '/shared/University of Michigan 01UMICH_INST/Reports/fake-data') do |row|
+  my_array.push(row)
+end
 ```

--- a/README.md
+++ b/README.md
@@ -97,3 +97,9 @@ Run the tests
 ```
 $ docker-compose run --rm web bundle exec rspec
 ```
+
+To run the gem in irb
+```
+$ docker-compose run --rm web bundle exec irb
+irb> client = AlmaRestClient.client
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     environment:
       - ALMA_API_HOST=https://api-na.hosted.exlibrisgroup.com
     env_file:
-      -.env
+      - .env
 volumes:
   gem_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - gem_cache:/gems
     environment:
       - ALMA_API_HOST=https://api-na.hosted.exlibrisgroup.com
-      - ALMA_API_KEY=almaapikey
+    env_file:
+      -.env
 volumes:
   gem_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,8 @@ services:
     volumes:
       - .:/app
       - gem_cache:/gems
-    environment:
-      - ALMA_API_HOST=https://api-na.hosted.exlibrisgroup.com
     env_file:
       - .env
+      - .env-dev-values
 volumes:
   gem_cache:

--- a/lib/alma_rest_client.rb
+++ b/lib/alma_rest_client.rb
@@ -94,18 +94,18 @@ module AlmaRestClient
       report_loop(xml, columns, query, &block) 
     end
     def report_loop(xml, columns, query, &block)
-        rows = xml["QueryResult"]["ResultXml"]["rowset"]["Row"]
-        rows = [ rows ] if rows.class == Hash
-        rows.each do |row|
-          my_row = {}
-          row.keys.each {|k| my_row[columns[k]] = row[k] }
-          block.call(my_row)
-        end
-        if xml["QueryResult"]["IsFinished"] != 'true'
-          response = get("/analytics/reports", query: query)
-          xml = Hash.from_xml(response.parsed_response["anies"].first)
-          report_loop(xml, columns, query, &block)
-        end
+      rows = xml["QueryResult"]["ResultXml"]["rowset"]["Row"]
+      rows = [ rows ] if rows.class == Hash
+      rows.each do |row|
+        my_row = {}
+        row.keys.each {|k| my_row[columns[k]] = row[k] }
+        block.call(my_row)
+      end
+      if xml["QueryResult"]["IsFinished"] != 'true'
+        response = get("/analytics/reports", query: query)
+        xml = Hash.from_xml(response.parsed_response["anies"].first)
+        report_loop(xml, columns, query, &block)
+      end
     end
     #query keys 'limit' and 'offset' will be overwritten
     def get_all_loop(url, record_key, limit, query={})

--- a/lib/alma_rest_client.rb
+++ b/lib/alma_rest_client.rb
@@ -13,7 +13,7 @@ module AlmaRestClient
       @parsed_response = parsed_response
     end
   end
-  class Client
+  class ClientBase
     include HTTParty
     base_uri "#{ENV.fetch('ALMA_API_HOST')}/almaws/v1"
 
@@ -27,6 +27,13 @@ module AlmaRestClient
       define_method(name) do |url, options={}|
         self.class.public_send(name, url, options)
       end
+    end
+  end
+  class Client 
+    extend Forwardable
+    def_delegators :@base_client, :get, :post, :delete, :put
+    def initialize(base_client=ClientBase.new)
+      @base_client = base_client
     end
 
     #record_key is the key that holds the array of items 
@@ -46,53 +53,54 @@ module AlmaRestClient
     def get_report(path:, filter: nil)
       query = { path: path, limit: 1000, col_names: true}
       try_count = 1
-      while try_count <= 2
-        response = report_loop(**query)
-        if response.code == 200
-          return response
+      begin 
+        report_loop(**query)
+      rescue 
+        if try_count < 2
+          try_count = try_count+1
+          retry
         else
-          try_count = try_count + 1
+          return Response.new(code: 500, message: 'Could not retrieve report.')
         end
       end
-      Response.new(code: 500, message: 'Could not retrieve report.')
     end
 
     private
+    def get_columns(xml)
+      col_raw = xml["QueryResult"]["ResultXml"]["rowset"]["schema"]["complexType"]["sequence"]["element"]
+      cols = col_raw.map {|x| [x["name"],  x["saw_sql:columnHeading"]] }.to_h
+    end
 
     def report_loop(path:,limit:,col_names:)
       output = []
-      columns = {}
       query = {path: path, limit: limit, col_names: col_names }
-      response = get("/analytics/reports", query: query)
-      if response.code != 200 
-        return Response.new(code: 500, message: 'Could not retrieve report.')
+      start_report(query) do |row|
+        output.push(row)
       end
+      Response.new(parsed_response: output)
+    end
+    def start_report(query, &block)
+      response = get("/analytics/reports", query: query)
+
       xml_string = response.parsed_response["anies"].first
       xml = Hash.from_xml(xml_string)
       query[:token] = xml["QueryResult"]["ResumptionToken"]
-      col_raw = xml["QueryResult"]["ResultXml"]["rowset"]["schema"]["complexType"]["sequence"]["element"]
-      col_raw.each {|x| columns[x["name"]] = x["saw-sql:columnHeading"] }
-
-      loop do
+      columns = get_columns(xml)
+      report_actual_loop(xml, columns, query, &block) 
+    end
+    def report_actual_loop(xml, columns, query, &block)
         rows = xml["QueryResult"]["ResultXml"]["rowset"]["Row"]
         rows = [ rows ] if rows.class == Hash
         rows.each do |row|
           my_row = {}
           row.keys.each {|k| my_row[columns[k]] = row[k] }
-          output.push(my_row)
+          block.call(my_row)
         end
-        if xml["QueryResult"]["IsFinished"] == 'true'
-          break
-        else
+        if xml["QueryResult"]["IsFinished"] != 'true'
           response = get("/analytics/reports", query: query)
-          if response.code == 200          
-            xml = Hash.from_xml(response.parsed_response["anies"].first)
-          else
-            return Response.new(code: 500, message: 'Could not retrieve report.')
-          end
+          xml = Hash.from_xml(response.parsed_response["anies"].first)
+          report_actual_loop(xml, columns, query, &block)
         end
-      end
-      Response.new(parsed_response: output)
     end
     #query keys 'limit' and 'offset' will be overwritten
     def get_all_loop(url, record_key, limit, query={})

--- a/spec/alma_rest_client_spec.rb
+++ b/spec/alma_rest_client_spec.rb
@@ -153,6 +153,14 @@ RSpec.describe AlmaRestClient::Client do
       expect(stub1).to have_been_requested.times(2)
       expect(stub2).to have_been_requested.times(2)
     end
+    it "can take a block" do
+      stub_alma_get_request(url: base_report_url, output: circ_history1, query: {**alma_query_params} )
+      stub_alma_get_request(url: base_report_url, output: circ_history2, query: {**alma_query_params, "token" => "fakeResumptionToken"} )
+      my_output = []
+      response = described_class.new.get_report(path: path){|row| my_output.push(row)}
+      expect(response.code).to eq(200)
+      expect(my_output.count).to eq(3) 
+    end
   end
   
 end

--- a/spec/alma_rest_client_spec.rb
+++ b/spec/alma_rest_client_spec.rb
@@ -79,24 +79,23 @@ RSpec.describe AlmaRestClient::Client do
       expect(response.class.name).to eq("AlmaRestClient::Response")
       expect(response.code).to eq(500)
       expect(response.message).to eq('Could not retrieve items.')
-      expect(stub1).to have_been_requested.times(2)
+      expect(stub1).to have_been_requested.times(1)
       expect(stub2).to have_been_requested.times(2)
     end
-    it "if alma requests fail to get everything the first time, it tries again and if it succeeds returns successful full results" do
+    it "if alma requests fail to get everything the first time, it tries the page call again and if it succeeds returns successful full results" do
       url = "users/jbister/loans"
       stub1 = stub_loan_0
       stub2 = stub_alma_get_request( query: { "limit" => 1, "offset" => 1}, url: url, status: 500) 
       stub2.then.to_return({body: loans1, status: 200, headers: {content_type: 'application/json'}}) 
 
       response = described_class.new.get_all(url: "/#{url}", record_key: "item_loan", limit:1)
-      expect(stub1).to have_been_requested.times(2)
+      expect(stub1).to have_been_requested.times(1)
       expect(stub2).to have_been_requested.times(2)
 
       expect(response.class.name).to eq("AlmaRestClient::Response")
       expect(response.code).to eq(200)
       expect(response.parsed_response["item_loan"].count).to eq(2)
     end
-
   end
   
   context "#get_report(path:, column_names: true)" do


### PR DESCRIPTION
This PR changes error handling for `get_all` and `get_report`. It now retries per page and uses raising exceptions instead of relying on codes from HTTParty. It also enable get_report to take a block.

The API is backwards compatible.

Also updated the Dockerfile to make development speedier.