### PR TITLE
Add request instrumentation

### DIFF
--- a/lib/alma_rest_client/client.rb
+++ b/lib/alma_rest_client/client.rb
@@ -13,6 +13,7 @@ module AlmaRestClient
       @conn.url_prefix = config.alma_api_host
 
       @conn.builder.build do |f|
+        f.request :instrumentation, name: "request.alma_rest_client"
         f.request :json
         f.request :retry, config.retry_options
         f.response :json


### PR DESCRIPTION
The instrumentation request middleware emits an ActiveSupport::Notification
 event with the supplied name. The event follows a pub/sub model, and
subscriptions look as follows:

```ruby
ActiveSupport::Notifications.subscribe("request.alma_rest_client") do |name, start, finish, id, payload|
   # ...
end
```