### PR TITLE
Allow array of parameters for http adapter

### DIFF
--- a/lib/alma_rest_client/client.rb
+++ b/lib/alma_rest_client/client.rb
@@ -16,7 +16,7 @@ module AlmaRestClient
         f.request :json
         f.request :retry, config.retry_options
         f.response :json
-        f.adapter config.http_adapter
+        f.adapter(*config.http_adapter)
       end
     end
     [:get, :post, :delete, :put].each do |name|

--- a/lib/alma_rest_client/configuration.rb
+++ b/lib/alma_rest_client/configuration.rb
@@ -1,11 +1,16 @@
 module AlmaRestClient
   class Configuration
-    attr_accessor :alma_api_key, :alma_api_host, :http_adapter, :retry_options
+    attr_accessor :alma_api_key, :alma_api_host, :retry_options
+    attr_writer :http_adapter
     def initialize
       @alma_api_key = ENV.fetch("ALMA_API_KEY", "")
       @alma_api_host = ENV.fetch("ALMA_API_HOST", "https://api-na.hosted.exlibrisgroup.com")
-      @http_adapter = :httpx
+      @http_adapter = [:httpx]
       @retry_options = {max: 1, retry_statuses: [500]}
+    end
+
+    def http_adapter
+      [@http_adapter].flatten
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -39,12 +39,16 @@ RSpec.describe AlmaRestClient, "#configuration" do
     end
   end
   context "http_adapter" do
-    it "can be set to something else" do
+    it "can be set to something else when given a symbol" do
       AlmaRestClient.configure { |config| config.http_adapter = :my_http_adapter }
-      expect(subject.http_adapter).to eq(:my_http_adapter)
+      expect(subject.http_adapter).to eq([:my_http_adapter])
+    end
+    it "can be set to an array" do
+      AlmaRestClient.configure { |config| config.http_adapter = [:my_http_adapter] }
+      expect(subject.http_adapter).to eq([:my_http_adapter])
     end
     it "has httpx as the default adapter" do
-      expect(subject.http_adapter).to eq(:httpx)
+      expect(subject.http_adapter).to eq([:httpx])
     end
   end
   context "retry_options" do


### PR DESCRIPTION
Previously the configuration option `http_adapter` only accepted a symbol. Now it will work for a symbol or an array, which will be given to the builder. 

This is so we can add additional settings to the http_adapter for the builder.